### PR TITLE
Fixed errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea/

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
       "scss"
     ],
     "globalVariables": [
-      "node_modules/react-toolbox/lib/_colors.scss", {
+      "node_modules/react-toolbox/lib/_colors.scss",
+      {
         "theme-building": true
       },
       "client/theme/toolbox-theme.scss"

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "immutability-helper": "^2.0.0",
     "mantra-core": "^1.2.0",
     "react": "^15.0.0",
+    "react-addons-css-transition-group": "^15.3.2",
     "react-dom": "^15.0.0",
     "react-komposer": "^1.3.0",
     "react-mounter": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
         "theme-building": true
       },
       "client/theme/toolbox-theme.scss"
+    ],
+    "ignorePaths": [
+      "node_modules/node-sass/"
     ]
   }
 }


### PR DESCRIPTION
The import error I got when running this was thanks to the test files included in the node-sass package. My css modules package errors when processing them because they aren't intended to be included in the package. Since Meteor automatically processes all the files it finds, you have to use the ignorePaths option to skip processing these files.

However, I'm not sure if this addresses your initial issue from nathantreid/meteor-css-modules#65.
